### PR TITLE
Gitleaks_Changes_Steps

### DIFF
--- a/Jenkinsfile_CI
+++ b/Jenkinsfile_CI
@@ -31,13 +31,12 @@ pipeline {
             }
         }
         
-        stage('GitLeaks Scan') {
+        stage('Gitleaks Scan') {
             steps {
-                sh 'gitleaks detect --source ./client --exit-code 1'
-                sh 'gitleaks detect --source ./api --exit-code 1'
+                sh 'gitleaks detect --source=./api --exit-code=1'
+                sh 'gitleaks detect --source=./client --exit-code=1'
             }
         }
-        
         stage('SonarQube Analysis') {
             steps {
                 withSonarQubeEnv('sonar') {


### PR DESCRIPTION
Updated the Gitleaks Scan stage in the Jenkins pipeline by adding the --exit-code=1 flag to the gitleaks detect commands for both the ./api and ./client directories.