### PR TITLE
Configure frontend API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,8 @@ The client now displays an animated banner welcoming you to **DevOps Shack**.
 ## Kubernetes Manifests
 
 The `k8s` directory contains example YAML manifests for deploying the MySQL database, backend API and frontend client on Kubernetes. Persistent volumes use the `ebs-sc` storage class, MySQL is initialized with the `init.sql` script and sensitive values are managed through Kubernetes secrets.
+
+The `frontend` deployment configures an environment variable `REACT_APP_API` with
+the internal URL of the backend service (`http://backend:5000`). Ensure the
+frontend image is built with this variable so that API requests are routed to the
+correct service when running in the cluster.

--- a/k8s/frontend.yaml
+++ b/k8s/frontend.yaml
@@ -12,11 +12,14 @@ spec:
       labels:
         app: frontend
     spec:
-      containers:
-        - name: frontend
-          image: your-repo/frontend:latest
-          ports:
-            - containerPort: 80
+        containers:
+          - name: frontend
+            image: your-repo/frontend:latest
+            ports:
+              - containerPort: 80
+            env:
+              - name: REACT_APP_API
+                value: http://backend:5000
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary
- point React frontend to the backend service
- document how the frontend picks up the backend URL

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b723fc81c8330ab5a816feb175f1c