### PR TITLE
Fix frontend API configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,16 @@ The `frontend` deployment configures an environment variable `REACT_APP_API` wit
 the internal URL of the backend service (`http://backend:5000`). Ensure the
 frontend image is built with this variable so that API requests are routed to the
 correct service when running in the cluster.
+
+### Building the frontend image
+
+When building the Docker image for the React frontend, pass the `REACT_APP_API`
+build argument so the compiled app knows how to reach the API:
+
+```bash
+docker-compose build frontend
+```
+
+The provided `docker-compose.yaml` already sets the argument to
+`http://localhost:5000` for local development. Update the value as needed for
+other environments.

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -3,6 +3,10 @@ FROM node:22-alpine AS builder
 
 WORKDIR /app
 
+# Allow API base URL to be injected at build time
+ARG REACT_APP_API=http://localhost:5000
+ENV REACT_APP_API=$REACT_APP_API
+
 # 🧠 Only copy dependency descriptors first to leverage Docker cache
 COPY package.json package-lock.json ./
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,10 @@ services:
       - "5000:5000"
 
   frontend:
-    build: ./client
+    build:
+      context: ./client
+      args:
+        - REACT_APP_API=http://localhost:5000
     container_name: frontend-react
     ports:
       - "3000:80"


### PR DESCRIPTION
## Summary
- allow Dockerfile for client to accept `REACT_APP_API` build argument
- pass build arg from `docker-compose.yaml`
- document how to build the frontend image with a custom API URL

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b7573a6388330b6c731ce800d1f8a